### PR TITLE
feat(lighttpd): enable CORS by default.

### DIFF
--- a/docker-files/lighttpd/lighttpd.conf
+++ b/docker-files/lighttpd/lighttpd.conf
@@ -5,7 +5,8 @@ server.modules = (
     "mod_access",
     "mod_accesslog",
     "mod_fastcgi",
-    "mod_rewrite"
+    "mod_rewrite",
+    "mod_setenv"
 )
 
 server.document-root = "/var/www/html"
@@ -24,7 +25,17 @@ include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.conf.pl"
 include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 
+setenv.add-response-header = (
+"Access-Control-Allow-Origin" => "*",
+"Access-Control-Allow-Methods" => "HEAD, GET, OPTIONS",
+"Access-Control-Expose-Headers" => "Content-Range, Date, Etag, Cache-Control, Last-Modified",
+"Access-Control-Allow-Headers" => "Content-Type, Origin, Accept, Range, Cache-Control",
+"Access-Control-Max-Age" => "600",
+"Timing-Allow-Origin" => "*" )
+
+
 fastcgi.server = ( "/" =>
+
     ((
         "bin-path" => "/usr/local/bin/iipsrv.fcgi",
         "socket" => "/var/run/lighttpd/iipsrv.socket",


### PR DESCRIPTION
This PR enables CORS so you can easily test it with for example [OpenLayers iiif viewer and package](https://openlayers.org/en/latest/examples/iiif.html).

